### PR TITLE
Install golangci-lint in .tools directory in Makefile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Run go tests and generate coverage report
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 coverage.out
 bin/*
+.tools/*


### PR DESCRIPTION
CI is currently failing because it requires golangci-lint, which does not exist in the CI environment. This PR updates the Makefile so that it includes a .tools directory, as well as a Make target for golangci-lint and reference to the vendored golangci-lint binary in the lint target.