### PR TITLE
Fix example config with more generic values

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,8 +1,8 @@
 server:
   socketpath: /tmp/runtime.sock
 permissions:
-  host: permissions-api.hollow-a.dc10.metalkube.net
+  host: permissions-api.enterprise.dev
 jwt:
-  jwksuri: https://iam.metalctrl.io/jwks.json
+  jwksuri: https://iam.enterprise.dev/jwks.json
 tracing:
   enabled: false


### PR DESCRIPTION
This PR updates the example config to use generic values users can swap out as needed.