### PR TITLE
Add .goreleaser.yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+
+includes:
+  - from_url:
+      url: https://raw.githubusercontent.com/infratographer/release/main/goreleaser/base.yml


### PR DESCRIPTION
This PR adds .goreleaser.yaml so we can deploy build artifacts the same way as we do in other Infratographer projects.