### PR TITLE
Fix Dockerfile and Makefile to build properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *~
 coverage.out
-bin/*
+iam-runtime-infratographer
 .tools/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,9 @@ FROM gcr.io/distroless/static:nonroot
 # `nonroot` coming from distroless
 USER 65532:65532
 
-# pass in name as --build-arg
-ARG NAME
+COPY iam-runtime-infratographer /bin/iam-runtime-infratographer
 
-COPY ./bin/${NAME} /app
+# Run the runtime service on container startup.
+ENTRYPOINT ["/bin/iam-runtime-infratographer"]
 
-# Run the web service on container startup.
-ENTRYPOINT ["/app"]
 CMD ["serve"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 TOOLS_DIR := .tools
+GOOS ?= linux
+GOARCH ?= amd64
 
 GOLANGCI_LINT_REPO = github.com/golangci/golangci-lint
 GOLANGCI_LINT_VERSION = v1.56.1
@@ -16,7 +18,7 @@ lint: $(TOOLS_DIR)/golangci-lint
 	@$(TOOLS_DIR)/golangci-lint run --modules-download-mode=readonly
 
 build:
-	@CGO_ENABLED=0 go build -mod=readonly -v -o bin/${APP_NAME}
+	@CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod=readonly -v
 
 go-dependencies:
 	@go mod download


### PR DESCRIPTION
This PR updates the Dockerfile to copy the binary from the root of the repo, which matches how GoReleaser works. To keep everything in the Makefile aligned, this commit also updates the build Make target to do the same thing and adds OS/architecture defaults.