### PR TITLE
Fix app name in root command and add schema.graphql file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const appName = "iam-runtime-equinix"
+const appName = "iam-runtime-infratographer"
 
 var (
 	cfgFile   string


### PR DESCRIPTION
This PR updates the app name in the root command to be correct and adds a schema.graphql file, which is necessary for GoReleaser to work.