### PR TITLE
Add junk content to schema.graphql

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,3 @@
+"""
+This is a placeholder for a GraphQL schema, which iam-runtime-infratographer does not have.
+"""


### PR DESCRIPTION
GoReleaser complains if schema.graphql does not contain data, it seems. This PR adds a comment to schema.graphql.