### PR TITLE
Update README with Make instructions instead of go build

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ iam-runtime-infratographer can be run as a standalone binary or a sidecar in a K
 To run it as a standalone binary using the provided example config, use the following commands:
 
 ```
-$ go build -mod=readonly -o bin/ .
-$ ./bin/iam-runtime-infratographer serve --config config.example.yaml
+$ make build # macOS users may need to run "GOOS=darwin make build"
+$ ./iam-runtime-infratographer serve --config config.example.yaml
 ```
 
 ## Configuration


### PR DESCRIPTION
This PR updates the README so that it uses the build Make target (with OS-specific arguments) instead of "go build".