### PR TITLE
Update Go to 1.22

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Run go tests and generate coverage report
         run: make test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.infratographer.com/iam-runtime-infratographer
 
-go 1.21.5
+go 1.22.1
 
 require (
 	github.com/MicahParks/jwkset v0.5.4


### PR DESCRIPTION
This commit updates Go in the module and actions workflows to 1.22.