### PR TITLE
use go version from go.mod

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Run go tests and generate coverage report
         run: make test


### PR DESCRIPTION
updates actions/setup-go to use go version from go.mod instead of tracking the go version separately