### PR TITLE
Optional NATS config / event publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ data:
       jwksuri: https://iam.example.com/jwks.json
       issuer: https://iam.example.com/
     events:
+      enabled: true
       nats:
         url: nats://nats:4222
         credsFile: /etc/nats/nats.creds
@@ -71,7 +72,7 @@ spec:
               - name: iam-runtime-socket
                 mountPath: /var/iam-runtime/
         - name: iam-runtime
-            image: ghcr.io/infratographer/iam-runtime-infratographer:v0.3.0
+            image: ghcr.io/infratographer/iam-runtime-infratographer:v0.3.1
             volumeMounts:
               - name: iam-runtime-config
                 mountPath: /etc/iam-runtime-infratographer/

--- a/internal/eventsx/config.go
+++ b/internal/eventsx/config.go
@@ -4,7 +4,8 @@ import "github.com/spf13/pflag"
 
 // Config represents a configuration for events.
 type Config struct {
-	NATS NATSConfig `mapstructure:"nats"`
+	Enabled bool       `mapstructure:"enabled"`
+	NATS    NATSConfig `mapstructure:"nats"`
 }
 
 // NATSConfig represents NATS-specific configuration for events.
@@ -18,6 +19,7 @@ type NATSConfig struct {
 
 // AddFlags sets the command line flags for publishing events.
 func AddFlags(flags *pflag.FlagSet) {
+	flags.Bool("events.enabled", false, "enable NATS event-based functions")
 	flags.String("events.nats.url", "", "NATS server URL to use")
 	flags.String("events.nats.publishprefix", "", "NATS publish prefix to use")
 	flags.String("events.nats.publishtopic", "", "NATS publish topic to use")

--- a/internal/eventsx/errors.go
+++ b/internal/eventsx/errors.go
@@ -1,0 +1,6 @@
+package eventsx
+
+import "errors"
+
+// ErrPublishNotEnabled represents an error state where an event publish was attempted despite not being enabled
+var ErrPublishNotEnabled = errors.New("event publishing is not enabled")

--- a/internal/eventsx/publisher.go
+++ b/internal/eventsx/publisher.go
@@ -23,6 +23,10 @@ func (p publisher) PublishAuthRelationshipRequest(ctx context.Context, message e
 
 // NewPublisher creates a new events publisher from the given config.
 func NewPublisher(cfg Config) (Publisher, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
 	natsCfg := events.NATSConfig{
 		URL:           cfg.NATS.URL,
 		PublishPrefix: cfg.NATS.PublishPrefix,


### PR DESCRIPTION
Not all projects will need event publishing, so it should be configurable such that ones that don't intend to use it don't need to have NATS credentials configured for them.