### PR TITLE
fix helm doc commit

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -1,25 +1,10 @@
-name: Helm lint and docs
+name: Helm docs
 on:
   push:
-  pull_request:
+    branches:
+      - main
 jobs:
-  helm-lint:
-    name: lint
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Helm
-        uses: azure/setup-helm@v3.5
-
-      - name: Run helm lint
-        run: helm lint chart/iam-runtime-infratographer
   helm-docs:
-    needs: helm-lint
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -43,6 +28,5 @@ jobs:
           commit_message: Helm docs updated
           commit_options: '--no-verify --signoff'
           file_pattern: 'chart/*/*.md'
-          skip_dirty_check: true
           skip_fetch: true
           skip_checkout: true

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,20 @@
+name: Helm lint
+on:
+  push:
+  pull_request:
+jobs:
+  helm-lint:
+    name: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3.5
+
+      - name: Run helm lint
+        run: helm lint chart/iam-runtime-infratographer

--- a/chart/iam-runtime-infratographer/README.md.gotmpl
+++ b/chart/iam-runtime-infratographer/README.md.gotmpl
@@ -1,8 +1,6 @@
 {{ template "chart.header" . }}
 {{ template "chart.description" . }}
 
-{{ template "chart.versionBadge" .  }}{{ template "chart.typeBadge" .  }}{{ template "chart.appVersionBadge" .  }}
-
 ## Example deployment
 
 Helm chart repository: https://infratographer.github.io/charts


### PR DESCRIPTION
Automatically committing to a fork doesn't work well. Instead we'll update the docs once the pr has been merged. This is the [suggested](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#use-in-forks-from-public-repositories) path when using a public fork.

Additionally, this fixes failure to commit when there is no diff in the docs and removes the badges as they don't get updated before tagging a release.