### PR TITLE
support client credentials being loaded from file

### DIFF
--- a/chart/iam-runtime-infratographer/README.md
+++ b/chart/iam-runtime-infratographer/README.md
@@ -58,8 +58,8 @@ iam-runtime-infratographer:
 | config.accessToken.exchange.grantType | string | urn:ietf:params:oauth:grant-type:token-exchange | grantType configures the grant type |
 | config.accessToken.exchange.issuer | string | `""` | issuer specifies the URL for the issuer for the exchanged token. The Issuer must support OpenID discovery to discover the token endpoint. |
 | config.accessToken.exchange.tokenType | string | urn:ietf:params:oauth:token-type:jwt | tokenType configures the token type |
-| config.accessToken.source.clientCredentials.clientID | string | `""` | clientID is the client credentials id which is used to retrieve a token from the issuer. |
-| config.accessToken.source.clientCredentials.clientSecret | string | `""` | clientSecret is the client credentials secret which is used to retrieve a token from the issuer. |
+| config.accessToken.source.clientCredentials.clientID | string | `""` | clientID is the client credentials id which is used to retrieve a token from the issuer. This attribute also supports a file path by prefixing the value with `file://`. example: `file:///var/secrets/client-id` |
+| config.accessToken.source.clientCredentials.clientSecret | string | `""` | clientSecret is the client credentials secret which is used to retrieve a token from the issuer. This attribute also supports a file path by prefixing the value with `file://`. example: `file:///var/secrets/client-secret` |
 | config.accessToken.source.clientCredentials.issuer | string | `""` | issuer specifies the URL for the issuer for the token request. The Issuer must support OpenID discovery to discover the token endpoint. |
 | config.accessToken.source.fileToken.noReuseToken | bool | `false` | noReuseToken if enabled disables reuse of tokens while they're still valid. |
 | config.accessToken.source.fileToken.tokenPath | string | `""` | tokenPath is the path to the source jwt token. |

--- a/chart/iam-runtime-infratographer/values.yaml
+++ b/chart/iam-runtime-infratographer/values.yaml
@@ -51,8 +51,12 @@ config:
         # The Issuer must support OpenID discovery to discover the token endpoint.
         issuer: ""
         # -- clientID is the client credentials id which is used to retrieve a token from the issuer.
+        # This attribute also supports a file path by prefixing the value with `file://`.
+        # example: `file:///var/secrets/client-id`
         clientID: ""
         # -- clientSecret is the client credentials secret which is used to retrieve a token from the issuer.
+        # This attribute also supports a file path by prefixing the value with `file://`.
+        # example: `file:///var/secrets/client-secret`
         clientSecret: ""
     exchange:
       # -- issuer specifies the URL for the issuer for the exchanged token.


### PR DESCRIPTION
The client creds secret, previously had to be specified in the config. When deploying this with the helm chart, this would require the value to be stored in plain text in the config map.

To solve this, we now accept a file path for both clientID and clientSecret.

If either attributes value is prefixed with `file://` the defined file is attempted to be loaded. If no file is found, or the file fails to be read, an error is returned.

Currently the file is only read once at startup.
However a future improvement could provide support for allowing hot reloading of the file.