### PR TITLE
Add int cast to reduce

### DIFF
--- a/chart/iam-runtime-infratographer/templates/_common.tpl
+++ b/chart/iam-runtime-infratographer/templates/_common.tpl
@@ -7,7 +7,7 @@
   {{- $prefix := include "iam-runtime-infratographer.fullname" .context }}
   {{- $reduce := sub (add (len $prefix) (len .suffix) 1) 63 }}
   {{- if gt $reduce 0 }}
-    {{- $prefix = trunc (add 63 $reduce) $prefix | trimSuffix "-" }}
+    {{- $prefix = trunc (add 63 $reduce | int) $prefix | trimSuffix "-" }}
   {{- end }}
   {{- printf "%s-%s" $prefix .suffix -}}
 {{- end }}


### PR DESCRIPTION
Running long name such as:

`helm --debug template . --name-template nam-arosidor-xnrertaue-service --namespace nam-arosidor-xnrertaue-service`

Getting an error:

```
Error: template: nam-arosidor-xnrertaue/templates/deployment.yaml:55:14: executing "nam-arosidor-xnrertaue/templates/deployment.yaml" at <include "iam-runtime-infratographer.volumeMounts" $>: error calling include: template: nam-arosidor-xnrertaue/charts/iam-runtime-infratographer/templates/_volumes.tpl:11:11: executing "iam-runtime-infratographer.volumeMounts" at <include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "socket" "context" $)>: error calling include: template: nam-arosidor-xnrertaue/charts/iam-runtime-infratographer/templates/_common.tpl:10:32: executing "iam-runtime-infratographer.resource.fullname" at <$reduce>: wrong type for value; expected int; got int64
helm.go:84: [debug] template: nam-arosidor-xnrertaue/templates/deployment.yaml:55:14: executing "nam-arosidor-xnrertaue/templates/deployment.yaml" at <include "iam-runtime-infratographer.volumeMounts" $>: error calling include: template: nam-arosidor-xnrertaue/charts/iam-runtime-infratographer/templates/_volumes.tpl:11:11: executing "iam-runtime-infratographer.volumeMounts" at <include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "socket" "context" $)>: error calling include: template: nam-arosidor-xnrertaue/charts/iam-runtime-infratographer/templates/_common.tpl:10:32: executing "iam-runtime-infratographer.resource.fullname" at <$reduce>: wrong type for value; expected int; got int64
```

Cast reduce to int fix the issue