### PR TITLE
Move secrets to secrets resource

### DIFF
--- a/chart/iam-runtime-infratographer/templates/_container.tpl
+++ b/chart/iam-runtime-infratographer/templates/_container.tpl
@@ -12,8 +12,23 @@ securityContext: {{- toYaml . | nindent 2 }}
 {{- with $values.resources }}
 resources: {{- toYaml . | nindent 2 }}
 {{- end }}
+env:
+  {{- with $values.secrets.nats.token }}
+  - name: IAMRUNTIME_EVENTS_NATS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        key: natsToken
+        name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
+  {{- end }}
+  {{- with $values.secrets.accessToken.source.clientSecret }}
+  - name: IAMRUNTIME_ACCESSTOKENPROVIDER_SOURCE_CLIENTCREDENTIALS_CLIENTSECRET
+    valueFrom:
+      secretKeyRef:
+        key: clientSecret
+        name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
+  {{- end }}
 {{- with $values.extraEnv }}
-env: {{- toYaml . | nindent 2 }}
+ {{- toYaml . | nindent 2 }}
 {{- end }}
 volumeMounts:
   - name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "config" "context" $) | quote }}

--- a/chart/iam-runtime-infratographer/templates/_secrets.tpl
+++ b/chart/iam-runtime-infratographer/templates/_secrets.tpl
@@ -1,0 +1,12 @@
+{{- define "iam-runtime-infratographer.secrets" }}
+{{- $values := (index .Subcharts "iam-runtime-infratographer").Values -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+data:
+  natsToken: {{ $values.secrets.nats.token | quote }}
+  clientSecret: {{ $values.secrets.accessToken.source.clientSecret | quote }}
+{{- end }}

--- a/chart/iam-runtime-infratographer/values.yaml
+++ b/chart/iam-runtime-infratographer/values.yaml
@@ -26,8 +26,6 @@ config:
       publishPrefix: ""
       # -- publishTopic NATS publihs topic to use.
       publishTopic: ""
-      # -- token NATS user token to use.
-      token: ""
       # -- credsFile path to NATS credentials file
       credsFile: ""
   tracing:
@@ -37,14 +35,14 @@ config:
     url: ""
     # -- insecure if TLS should be disabled.
     insecure: false
-  accessToken:
+  accessTokenProvider:
     # -- enabled configures the access token source for GetAccessToken requests.
     enabled: false
     # -- (duration) expiryDelta sets early expiry validation for the token.
     # @default -- 10s
     expiryDelta: 0
     source:
-      fileToken:
+      file:
         # -- tokenPath is the path to the source jwt token.
         tokenPath: ""
       clientCredentials:
@@ -55,10 +53,6 @@ config:
         # This attribute also supports a file path by prefixing the value with `file://`.
         # example: `file:///var/secrets/client-id`
         clientID: ""
-        # -- clientSecret is the client credentials secret which is used to retrieve a token from the issuer.
-        # This attribute also supports a file path by prefixing the value with `file://`.
-        # example: `file:///var/secrets/client-secret`
-        clientSecret: ""
     exchange:
       # -- issuer specifies the URL for the issuer for the exchanged token.
       # The Issuer must support OpenID discovery to discover the token endpoint.
@@ -69,6 +63,18 @@ config:
       # -- tokenType configures the token type
       # @default -- urn:ietf:params:oauth:token-type:jwt
       tokenType: ""
+
+secrets:
+  nats:
+    # -- token NATS user token to use.
+    token: ""
+  accessToken:
+    source:
+      # -- clientSecret is the client credentials secret which is used to retrieve a token from the issuer.
+      # This attribute also supports a file path by prefixing the value with `file://`.
+      # example: `file:///var/secrets/client-secret`
+      clientSecret: ""
+
 
 # -- restartPolicy set to Always if using with initContainers on kube 1.29 and up
 # with the SideContainer feature flag enabled.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -35,6 +35,7 @@ func init() {
 	permissions.AddFlags(cmdFlags)
 	eventsx.AddFlags(cmdFlags)
 	server.AddFlags(cmdFlags)
+	accesstoken.AddFlags(cmdFlags)
 
 	if err := viper.BindPFlags(cmdFlags); err != nil {
 		panic(err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,10 +12,10 @@ events:
     publishTopic: myapp
 tracing:
   enabled: false
-accessToken:
+accessTokenProvider:
   enabled: false
   source:
-    fileToken:
+    file:
       tokenPath: /var/run/secrets/kubernetes.io/serviceaccount/token
     # clientCredentials:
     #   issuer: https://identity-api.enterprise.dev/

--- a/internal/accesstoken/tokensource.go
+++ b/internal/accesstoken/tokensource.go
@@ -36,8 +36,8 @@ func (c AccessTokenSourceConfig) toTokenSource(ctx context.Context) (oauth2.Toke
 		return nil, err
 	}
 
-	if c.FileToken.Configured() {
-		tokensource, err := c.FileToken.ToTokenSource()
+	if c.File.Configured() {
+		tokensource, err := c.File.ToTokenSource()
 		if err != nil {
 			return nil, fmt.Errorf("file token: %w", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,5 +16,5 @@ type Config struct {
 	Events      eventsx.Config
 	Server      server.Config
 	Tracing     otelx.Config
-	AccessToken accesstoken.Config
+	AccessToken accesstoken.Config `mapstructure:"accessTokenProvider"`
 }


### PR DESCRIPTION
This PR moves the NATS token and `accessToken.source.clientCredentials.clientSecret` out from the configMap and into secrets loaded as environment variables in the container.

FileToken.TokenPath gets flagged by secrets scanners despite it not being a sensitive credential, so that got renamed to just `File` which still makes sense in the config path `accessToken.source.file.tokenPath`.

AccessToken was also giving chart consumers trouble with security scans, so that was renamed to accessTokenProvider.


Breaking changes from existing chart:
* Configuration for GetAccessToken now changes from `accessToken` to `accessTokenProvider`
* File token path changes from `accessTokenProvider.source.fileToken.tokenPath` to `accessTokenProvider.source.file.tokenPath` (`s/fileToken/file/`)
* Downstream charts which depend on this chart must also deploy `iam-runtime-infratographer.secrets` within the namespace if loading configuration from `events.nats.token` and `accessTokenProvider.source.clientCredentials.clientSecret` for the runtime.