### PR TITLE
Move to `iam-runtime-infratographer.manifests`

### DIFF
--- a/chart/iam-runtime-infratographer/templates/_container.tpl
+++ b/chart/iam-runtime-infratographer/templates/_container.tpl
@@ -12,22 +12,11 @@ securityContext: {{- toYaml . | nindent 2 }}
 {{- with $values.resources }}
 resources: {{- toYaml . | nindent 2 }}
 {{- end }}
-env:
-  {{- with $values.secrets.nats.token }}
-  - name: IAMRUNTIME_EVENTS_NATS_TOKEN
-    valueFrom:
-      secretKeyRef:
-        key: natsToken
-        name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
-  {{- end }}
-  {{- with $values.secrets.accessToken.source.clientSecret }}
-  - name: IAMRUNTIME_ACCESSTOKENPROVIDER_SOURCE_CLIENTCREDENTIALS_CLIENTSECRET
-    valueFrom:
-      secretKeyRef:
-        key: clientSecret
-        name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
-  {{- end }}
+envFrom:
+  - secretRef:
+      name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
 {{- with $values.extraEnv }}
+env:
  {{- toYaml . | nindent 2 }}
 {{- end }}
 volumeMounts:

--- a/chart/iam-runtime-infratographer/templates/_manifests.tpl
+++ b/chart/iam-runtime-infratographer/templates/_manifests.tpl
@@ -1,0 +1,4 @@
+{{- define "iam-runtime-infratographer.manifests" }}
+{{ include "iam-runtime-infratographer.configmap" $ }}
+{{ include "iam-runtime-infratographer.secrets" $ }}
+{{- end }}

--- a/chart/iam-runtime-infratographer/templates/_secrets.tpl
+++ b/chart/iam-runtime-infratographer/templates/_secrets.tpl
@@ -7,6 +7,6 @@ metadata:
   name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
 data:
-  natsToken: {{ $values.secrets.nats.token | quote }}
-  clientSecret: {{ $values.secrets.accessToken.source.clientSecret | quote }}
+  IAMRUNTIME_EVENTS_NATS_TOKEN: {{ $values.secrets.nats.token | quote }}
+  IAMRUNTIME_ACCESSTOKENPROVIDER_SOURCE_CLIENTCREDENTIALS_CLIENTSECRET: {{ $values.secrets.accessToken.source.clientSecret | quote }}
 {{- end }}


### PR DESCRIPTION
This makes it easier for applications depending on this chart to include the required configuration. Now an application can just add the following: 
```
{{ include "iam-runtime-infratographer.manifests" $ }}
```

And we'll be able to plug in any supporting manifests we need to support the runtime.