### PR TITLE
provide failure message when not using the new manifests helper

### DIFF
--- a/chart/iam-runtime-infratographer/templates/_configmap.tpl
+++ b/chart/iam-runtime-infratographer/templates/_configmap.tpl
@@ -1,4 +1,8 @@
 {{- define "iam-runtime-infratographer.configmap" }}
+{{ fail "iam-runtime-infratographer.configmap has been deprecated, use iam-runtime-infratographer.manifests instead." }}
+{{- end }}
+
+{{- define "iam-runtime-infratographer._configmap" }}
 {{- $values := (index .Subcharts "iam-runtime-infratographer").Values -}}
 {{- $defaultConfig := dict "server" (dict "socketPath" "/var/iam-runtime/runtime.sock") }}
 {{- $config := include "iam-runtime-infratographer.omit" (dict

--- a/chart/iam-runtime-infratographer/templates/_manifests.tpl
+++ b/chart/iam-runtime-infratographer/templates/_manifests.tpl
@@ -1,4 +1,4 @@
 {{- define "iam-runtime-infratographer.manifests" }}
-{{ include "iam-runtime-infratographer.configmap" $ }}
-{{ include "iam-runtime-infratographer.secrets" $ }}
+{{ include "iam-runtime-infratographer._configmap" $ }}
+{{ include "iam-runtime-infratographer._secrets" $ }}
 {{- end }}

--- a/chart/iam-runtime-infratographer/templates/_secrets.tpl
+++ b/chart/iam-runtime-infratographer/templates/_secrets.tpl
@@ -1,4 +1,4 @@
-{{- define "iam-runtime-infratographer.secrets" }}
+{{- define "iam-runtime-infratographer._secrets" }}
 {{- $values := (index .Subcharts "iam-runtime-infratographer").Values -}}
 ---
 apiVersion: v1


### PR DESCRIPTION
With the split of the config into both a configmap and secrets a new helper was created `manifests` which will include both of these manifests.

This however means that the configmap helper must no longer be used otherwise the secrets manifest resulting in missing dependencies.

To ensure this breaking change is clear, we renamed configmap and put a deprecation message in it's place, informing the user of how to resolve the issue.