### PR TITLE
fix secret data field

### DIFF
--- a/chart/iam-runtime-infratographer/templates/_secrets.tpl
+++ b/chart/iam-runtime-infratographer/templates/_secrets.tpl
@@ -6,7 +6,7 @@ kind: Secret
 metadata:
   name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "secrets" "context" $) | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-data:
+stringData:
   {{- with $values.config.events.nats.token }}
   IAMRUNTIME_EVENTS_NATS_TOKEN: {{ quote . }}
   {{- end }}


### PR DESCRIPTION
This chart was not encoding the data values as base64 or using stringData which results in an invalid secret value. This changes the field to use stringData which will encode the value on apply.