### PR TITLE
implement grpc health check service

### DIFF
--- a/chart/iam-runtime-infratographer/templates/_container.tpl
+++ b/chart/iam-runtime-infratographer/templates/_container.tpl
@@ -19,6 +19,16 @@ envFrom:
 env:
  {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- if $values.livenessProbe.enabled }}
+{{- with omit $values.livenessProbe "enabled" }}
+livenessProbe: {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- if $values.readinessProbe.enabled }}
+{{- with omit $values.readinessProbe "enabled" }}
+readinessProbe: {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
 volumeMounts:
   - name: {{ include "iam-runtime-infratographer.resource.fullname" (dict "suffix" "config" "context" $) | quote }}
     mountPath: /etc/iam-runtime-infratographer/

--- a/chart/iam-runtime-infratographer/values.yaml
+++ b/chart/iam-runtime-infratographer/values.yaml
@@ -127,3 +127,19 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 65532
+
+livenessProbe:
+  # -- enables liveness probe.
+  enabled: true
+  grpc:
+    # -- sets the grpc health service port.
+    port: 4784
+  timeoutSeconds: 10
+
+readinessProbe:
+  # -- enables readiness probe.
+  enabled: true
+  grpc:
+    # -- sets the grpc health service port.
+    port: 4784
+  timeoutSeconds: 10

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/metal-toolbox/iam-runtime v0.4.1
+	github.com/nats-io/nats.go v1.36.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
@@ -52,7 +53,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/nats-io/nats.go v1.36.0 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect

--- a/internal/eventsx/errors.go
+++ b/internal/eventsx/errors.go
@@ -2,5 +2,10 @@ package eventsx
 
 import "errors"
 
-// ErrPublishNotEnabled represents an error state where an event publish was attempted despite not being enabled
-var ErrPublishNotEnabled = errors.New("event publishing is not enabled")
+var (
+	// ErrPublishNotEnabled represents an error state where an event publish was attempted despite not being enabled
+	ErrPublishNotEnabled = errors.New("event publishing is not enabled")
+
+	// ErrPublisherNotConnected is returned when the underlying connection status is not CONNECTED.
+	ErrPublisherNotConnected = errors.New("event publisher is not connected")
+)

--- a/internal/eventsx/publisher.go
+++ b/internal/eventsx/publisher.go
@@ -2,14 +2,26 @@ package eventsx
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/nats-io/nats.go"
 	"go.infratographer.com/x/events"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
+
+const tracerName = "go.infratographer.com/iam-runtime-infratographer/internal/eventsx"
+
+var tracer = otel.GetTracerProvider().Tracer(tracerName)
 
 // Publisher represents something that sends relationships to permissions-api via NATS.
 type Publisher interface {
 	// PublishAuthRelationship is similar to events.Publisher.PublishAuthRelationship, but with no topic.
 	PublishAuthRelationshipRequest(ctx context.Context, message events.AuthRelationshipRequest) (events.Message[events.AuthRelationshipResponse], error)
+
+	// HealthCheck returns nil when the service is healthy.
+	HealthCheck(ctx context.Context) error
 }
 
 type publisher struct {
@@ -23,6 +35,30 @@ func (p publisher) PublishAuthRelationshipRequest(ctx context.Context, message e
 		return nil, ErrPublishNotEnabled
 	}
 	return p.innerPub.PublishAuthRelationshipRequest(ctx, p.topic, message)
+}
+
+// HealthCheck returns nil when the service is healthy.
+func (p publisher) HealthCheck(ctx context.Context) error {
+	_, span := tracer.Start(ctx, "HealthCheck")
+	defer span.End()
+
+	if !p.enabled {
+		span.SetAttributes(attribute.String("healthcheck.outcome", "disabled"))
+
+		return nil
+	}
+
+	conn := p.innerPub.(*events.NATSConnection).Source().(*nats.Conn)
+	if conn.Status() != nats.CONNECTED {
+		span.SetStatus(codes.Error, fmt.Sprintf("status not connected: %s", conn.Status()))
+		span.SetAttributes(attribute.String("healthcheck.outcome", "unhealthy"))
+
+		return fmt.Errorf("%w: status: %s", ErrPublisherNotConnected, conn.Status())
+	}
+
+	span.SetAttributes(attribute.String("healthcheck.outcome", "healthy"))
+
+	return nil
 }
 
 // NewPublisher creates a new events publisher from the given config.

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -6,10 +6,12 @@ import (
 
 // Config represents a configuration for an IAM runtime server.
 type Config struct {
-	SocketPath string
+	SocketPath    string
+	HealthAddress string
 }
 
 // AddFlags sets the command line flags for the IAM runtime server.
 func AddFlags(flags *pflag.FlagSet) {
 	flags.String("server.socketpath", "", "gRPC server socket path")
+	flags.String("server.healthaddress", ":4784", "gRPC health server listen address")
 }

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -7,4 +7,6 @@ var (
 	ErrDuplicateValue = errors.New("duplicate value")
 	// ErrMissingValue represents an error where a required value was missing from a policy.
 	ErrMissingValue = errors.New("missing value")
+	// ErrServerNotRunning is returned by the server health check when the server is not running.
+	ErrServerNotRunning = errors.New("server not running")
 )

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	health "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+const serviceHealthCheckTimeout = 30 * time.Second
+
+// HealthCheck defines a health checker service.
+type HealthChecker interface {
+	HealthCheck(ctx context.Context) error
+}
+
+// HealthChecks specifies a service name and the health check function to call.
+type HealthChecks map[string]HealthChecker
+
+var _ health.HealthServer = (*server)(nil)
+
+// Check implements Health service checks.
+func (s *server) Check(ctx context.Context, in *health.HealthCheckRequest) (*health.HealthCheckResponse, error) {
+	span := trace.SpanFromContext(ctx)
+
+	s.logger.Info("received HealthCheck request")
+
+	status := health.HealthCheckResponse_SERVING
+
+	if s.healthChecks != nil {
+		for name, svc := range s.healthChecks {
+			if in.GetService() != "" && in.GetService() != name {
+				continue
+			}
+
+			chkCtx, cancel := context.WithTimeout(ctx, serviceHealthCheckTimeout)
+			defer cancel()
+
+			if err := svc.HealthCheck(chkCtx); err == nil {
+				s.logger.Debugf("Service %s healthy", name)
+			} else {
+				s.logger.Errorf("Service %s unhealthy: %s", name, err.Error())
+
+				status = health.HealthCheckResponse_NOT_SERVING
+
+				break
+			}
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("healthcheck.outcome", status.String()),
+	)
+
+	resp := &health.HealthCheckResponse{
+		Status: status,
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
This implements the standard grpc health check service methods.

Extending each underlying service library to include a HealthCheck method called by the GRPC HealthService Check.