### PR TITLE
support disabling default services

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,7 @@
 server:
   socketpath: /tmp/runtime.sock
 permissions:
+  disable: false
   host: permissions-api.enterprise.dev
   discovery:
     disable: false
@@ -18,6 +19,7 @@ permissions:
       timeout: 2s
       concurrency: 5
 jwt:
+  disable: false
   jwksuri: https://identity-api.enterprise.dev/jwks.json
   issuer: https://identity-api.enterprise.dev/
 events:

--- a/internal/jwt/config.go
+++ b/internal/jwt/config.go
@@ -6,12 +6,14 @@ import (
 
 // Config represents the configuration for a JWT validator.
 type Config struct {
+	Disable bool
 	Issuer  string
 	JWKSURI string
 }
 
 // AddFlags sets the command line flags for JWT validation.
 func AddFlags(flags *pflag.FlagSet) {
+	flags.Bool("jwt.disable", false, "Disable JWT service")
 	flags.String("jwt.issuer", "", "Issuer to use for JWT validation")
 	flags.String("jwt.jwksuri", "", "JWKS URI to use for JWT validation")
 }

--- a/internal/permissions/config.go
+++ b/internal/permissions/config.go
@@ -11,6 +11,9 @@ import (
 
 // Config represents a permissions-api client configuration.
 type Config struct {
+	// Disable disables the permissions service.
+	Disable bool
+
 	// Host represents a permissions-api host to hit.
 	Host string
 
@@ -21,7 +24,7 @@ type Config struct {
 func (c Config) initTransport(base http.RoundTripper, opts ...selecthost.Option) (http.RoundTripper, error) {
 	base = otelhttp.NewTransport(base)
 
-	if c.Discovery.Disable {
+	if c.Disable || c.Discovery.Disable {
 		return base, nil
 	}
 
@@ -170,5 +173,6 @@ type CheckConfig struct {
 
 // AddFlags sets the command line flags for the permissions-api client.
 func AddFlags(flags *pflag.FlagSet) {
+	flags.Bool("permissions.disable", false, "disables permissions service")
 	flags.String("permissions.host", "", "permissions-api host to use")
 }

--- a/internal/permissions/errors.go
+++ b/internal/permissions/errors.go
@@ -3,6 +3,9 @@ package permissions
 import "errors"
 
 var (
+	// ErrServiceDisabled is returned when calling a service method while the service is disabled.
+	ErrServiceDisabled = errors.New("permissions service disabled")
+
 	// ErrUnauthenticated represents an error state where the subject failed to authenticate
 	// against permissions-api.
 	ErrUnauthenticated = errors.New("invalid credentials")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -191,6 +191,12 @@ func (s *server) ValidateCredential(ctx context.Context, req *authentication.Val
 
 	sub, claims, err := s.validator.ValidateToken(req.Credential)
 	if err != nil {
+		if errors.Is(err, jwt.ErrServiceDisabled) {
+			span.SetStatus(tcodes.Error, err.Error())
+
+			return nil, err
+		}
+
 		span.RecordError(err)
 
 		s.logger.Errorw("invalid token", "error", err)


### PR DESCRIPTION
IAM Runtime's default services JWT and Permissions are always enabled by default. This allows those services to be disabled therefore ensuring health checks pass when not used.

These services may not always be used in cases when the runtime is only used for other services such as retrieving an access token if the service only makes requests out.