### PR TITLE
chore(release): keep release notes from release-please

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+version: 2
 
 includes:
   - from_url:
       url: https://raw.githubusercontent.com/infratographer/release/main/goreleaser/base.yml
+
+release:
+  mode: keep-existing


### PR DESCRIPTION
The imported goreleaser config sets `mode: prepend` which results in duplicate change logs in the published release notes. This instructs goreleaser to keep the existing release notes which were already pushed by release-please.