### PR TITLE
fix(auth): add AuthStyleInParams to prevent empty Auth Header

### DIFF
--- a/internal/accesstoken/tokenexchange.go
+++ b/internal/accesstoken/tokenexchange.go
@@ -92,7 +92,8 @@ func newExchangeTokenSource(ctx context.Context, cfg ExchangeConfig, upstream oa
 		upstream: upstream,
 		exchangeConfig: oauth2.Config{
 			Endpoint: oauth2.Endpoint{
-				TokenURL: tokenEndpoint,
+				TokenURL:  tokenEndpoint,
+				AuthStyle: oauth2.AuthStyleInParams,
 			},
 		},
 	}, nil

--- a/internal/accesstoken/tokenexchange_test.go
+++ b/internal/accesstoken/tokenexchange_test.go
@@ -1,0 +1,69 @@
+package accesstoken
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type staticTokenSource struct {
+	token *oauth2.Token
+}
+
+func (s *staticTokenSource) Token() (*oauth2.Token, error) {
+	return s.token, nil
+}
+
+// TestTokenExchangeNoAuthHeaderWithoutCredentials verifies that no Authorization header
+// is sent during an RFC 8693 token exchange when no client credentials are configured.
+// Without AuthStyleInParams, the oauth2 package defaults to AuthStyleAutoDetect which
+// probes with Basic auth first, injecting "Basic Og==" (base64 of ":") even when both
+// ClientID and ClientSecret are empty.
+func TestTokenExchangeNoAuthHeaderWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	var (
+		capturedAuthHeader string
+		capturedForm       map[string][]string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuthHeader = r.Header.Get("Authorization")
+
+		require.NoError(t, r.ParseForm())
+		capturedForm = r.Form
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"exchanged-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(server.Close)
+
+	src := &exchangeTokenSource{
+		cfg: ExchangeConfig{
+			GrantType: defaultGrantType,
+			TokenType: defaultTokenType,
+		},
+		ctx: context.Background(),
+		upstream: &staticTokenSource{
+			token: &oauth2.Token{AccessToken: "upstream-token"},
+		},
+		exchangeConfig: oauth2.Config{
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  server.URL + "/token",
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+		},
+	}
+
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	assert.Empty(t, capturedAuthHeader, "expected no Authorization header when no client credentials are configured")
+	assert.NotContains(t, capturedForm, "client_id", "expected no client_id in request body")
+	assert.NotContains(t, capturedForm, "client_secret", "expected no client_secret in request body")
+}


### PR DESCRIPTION
This pull request improves the handling of OAuth2 token exchanges when no client credentials are configured, ensuring compliance with RFC 8693 and preventing unintended Authorization headers from being sent. It also adds a targeted test to verify this behavior.

**OAuth2 Token Exchange Handling:**

* Updated the `exchangeTokenSource` configuration in `tokenexchange.go` to explicitly set `AuthStyle` to `oauth2.AuthStyleInParams`, ensuring that the Authorization header is not sent when client credentials are absent.

**Testing Improvements:**

* Added a new test `TestTokenExchangeNoAuthHeaderWithoutCredentials` in `tokenexchange_test.go` to verify that no Authorization header or client credentials are sent during token exchange when none are configured.